### PR TITLE
Create and use Framed<_, HttpCodec> internally

### DIFF
--- a/examples/http.rs
+++ b/examples/http.rs
@@ -12,8 +12,7 @@ fn main() {
     let addr = req.addr().unwrap();
     let handle = core.handle();
     let (res, _) = core.run(TcpStream::connect(&addr, &handle).and_then(|connection| {
-        let framed = connection.framed(HttpCodec::new());
-        req.send(framed)
+        req.send(connection)
     })).unwrap();
     println!("got response {}", res.unwrap());
 }

--- a/examples/https.rs
+++ b/examples/https.rs
@@ -31,8 +31,7 @@ fn main() {
     });
 
     let (res, _) = core.run(tls_handshake.and_then(|connection| {
-        let framed = connection.framed(HttpCodec::new());
-        let result = req.send(framed);
+        let result = req.send(connection);
         return result;
     })).unwrap();
 


### PR DESCRIPTION
It would be more logical if `HttpRequest` would accept an `Io` object in its `send` method instead of a `Framed` object created with the `HttpCodec` as this library is not meant to be used with another codec.

It simplifies a bit the use of the library and is in my opinion more logical.